### PR TITLE
Backport looker diffs from other repo

### DIFF
--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -38,7 +38,8 @@
                     orderBy: "@",
                     reverseOrder: "@",
                     filterExpression: "=?",
-                    filterComparator: "=?"
+                    filterComparator: "=?",
+                    disabledExpression: "=?",
                 },
                 controller: ['$scope', function( $scope ) {
 
@@ -113,18 +114,24 @@
                             return false;
                         }
                     }
+                    $scope.disabledExpression = (angular.isFunction($scope.disabledExpression) ? $scope.disabledExpression : function () { return false; })
 
                     $scope.headClass = function(node) {
                         var liSelectionClass = classIfDefined($scope.options.injectClasses.liSelected, false);
                         var injectSelectionClass = "";
                         if (liSelectionClass && isSelectedNode(node))
                             injectSelectionClass = " " + liSelectionClass;
+
+                        var output = ""
                         if ($scope.options.isLeaf(node))
-                            return "tree-leaf" + injectSelectionClass;
+                            output = "tree-leaf" + injectSelectionClass;
                         if ($scope.expandedNodesMap[this.$id])
-                            return "tree-expanded" + injectSelectionClass;
+                            output = "tree-expanded" + injectSelectionClass;
                         else
-                            return "tree-collapsed" + injectSelectionClass;
+                            output = "tree-collapsed" + injectSelectionClass;
+                        if ($scope.disabledExpression(node))
+                            output = [output, "disabled"].join(" ");
+                        return output;
                     };
 
                     $scope.iBranchClass = function() {
@@ -139,6 +146,7 @@
                     };
 
                     $scope.selectNodeHead = function() {
+                        if ($scope.disabledExpression(this.node)) return;
                         var expanding = $scope.expandedNodesMap[this.$id] === undefined;
                         $scope.expandedNodesMap[this.$id] = (expanding ? this.node : undefined);
                         if (expanding) {
@@ -159,6 +167,7 @@
                     };
 
                     $scope.selectNodeLabel = function( selectedNode ){
+                        if ($scope.disabledExpression(selectedNode)) return;
                         if (selectedNode[$scope.options.nodeChildren] && selectedNode[$scope.options.nodeChildren].length > 0 &&
                             !$scope.options.dirSelectable) {
                             this.selectNodeHead();

--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -134,6 +134,11 @@
                             output = "tree-collapsed" + injectSelectionClass;
                         }
 
+                        // Hack for showing and hiding the expandor triangle
+                        if (!$scope.options.isLeaf(node) && !node[$scope.options.nodeChildren].length) {
+                            output = output + " no-children";
+                        }
+
                         if ($scope.disabledExpression && $scope.disabledExpression(node))
                             output = [output, "disabled"].join(" ");
 
@@ -173,9 +178,11 @@
                     };
 
                     $scope.selectNodeLabel = function( selectedNode ){
+
                         if ($scope.disabledExpression(selectedNode)) return;
-                        if (selectedNode[$scope.options.nodeChildren] && selectedNode[$scope.options.nodeChildren].length > 0 &&
-                            !$scope.options.dirSelectable) {
+
+                        // From https://github.com/wix/angular-tree-control/pull/122/files
+                        if(!$scope.options.isLeaf(selectedNode) && !$scope.options.dirSelectable) {
                             this.selectNodeHead();
                         }
                         else {
@@ -228,10 +235,10 @@
                     var template =
                         '<ul '+classIfDefined($scope.options.injectClasses.ul, true)+'>' +
                             '<li ng-repeat="node in node.' + $scope.options.nodeChildren + ' | filter:filterExpression:filterComparator ' + orderBy + '" ng-class="headClass(node)" '+classIfDefined($scope.options.injectClasses.li, true)+'>' +
-                            '<i class="tree-branch-head" ng-class="iBranchClass()" ng-click="selectNodeHead(node)"></i>' +
-                            '<i class="tree-leaf-head '+classIfDefined($scope.options.injectClasses.iLeaf, false)+'"></i>' +
-                            '<div class="tree-label '+classIfDefined($scope.options.injectClasses.label, false)+'" ng-class="selectedClass()" ng-click="selectNodeLabel(node)" tree-transclude></div>' +
-                            '<treeitem ng-if="nodeExpanded()"></treeitem>' +
+                                '<i class="tree-branch-head" ng-class="iBranchClass()" ng-click="selectNodeHead(node)"></i>' +
+                                '<i class="tree-leaf-head '+classIfDefined($scope.options.injectClasses.iLeaf, false)+'"></i>' +
+                                '<div class="tree-label '+classIfDefined($scope.options.injectClasses.label, false)+'" ng-class="selectedClass()" ng-click="selectNodeLabel(node)" tree-transclude></div>' +
+                                '<treeitem ng-if="nodeExpanded()"></treeitem>' +
                             '</li>' +
                             '</ul>';
 

--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -114,7 +114,10 @@
                             return false;
                         }
                     }
-                    $scope.disabledExpression = (angular.isFunction($scope.disabledExpression) ? $scope.disabledExpression : function () { return false; })
+
+                    if (!angular.isFunction($scope.disabledExpression)) {
+                        $scope.disabledExpression = function() { return false; }
+                    }
 
                     $scope.headClass = function(node) {
                         var liSelectionClass = classIfDefined($scope.options.injectClasses.liSelected, false);
@@ -123,14 +126,17 @@
                             injectSelectionClass = " " + liSelectionClass;
 
                         var output = ""
-                        if ($scope.options.isLeaf(node))
+                        if ($scope.options.isLeaf(node)) {
                             output = "tree-leaf" + injectSelectionClass;
-                        if ($scope.expandedNodesMap[this.$id])
+                        } else if ($scope.expandedNodesMap[this.$id]) {
                             output = "tree-expanded" + injectSelectionClass;
-                        else
+                        } else {
                             output = "tree-collapsed" + injectSelectionClass;
-                        if ($scope.disabledExpression(node))
+                        }
+
+                        if ($scope.disabledExpression && $scope.disabledExpression(node))
                             output = [output, "disabled"].join(" ");
+
                         return output;
                     };
 


### PR DESCRIPTION
Cherrypick patches from helltool.git which were made on top of this file when it was housed there as vendor code.

Includes this history:
commit 5678dee28bb706198f769ff5c2ced7c24ab01456
Author: Nathan Agrin <n8agrin@gmail.com>
Date:   Mon May 11 16:41:39 2015 -0700

    Create a way to remove the dropdown arrow for spaces with no children
    
    Fixes #9147

commit 83c84a0fe0c8b27225796e0c72932c8d872d14cf
Author: Nathan Agrin <n8agrin@gmail.com>
Date:   Wed May 6 12:19:33 2015 -0700

    Fix some styling bugs because return is no longer return

commit 7004b9d57a78969133e9b52c5f8190f194d2d552
Author: Nathan Agrin <n8agrin@gmail.com>
Date:   Wed May 6 10:56:59 2015 -0700

    Allow spaces to be disabled.

commit 87fdb2c86f293d55737e6372fcddeebf9eac7531
Author: Nathan Agrin <n8agrin@gmail.com>
Date:   Mon May 4 17:51:47 2015 -0700

    Prevent clicking an asset other than a space from getting selected.
    
    Resolves #8943

commit 559bd70e1b01f1f684c4f0b1db746441be88b042
Author: Nathan Agrin <n8agrin@gmail.com>
Date:   Mon May 4 17:15:48 2015 -0700

    Can't deslect the chosen space now.
    
    Closes #8942

commit b622684af081ca706ca88e9e94ca4f468e933901
Author: Nathan Agrin <n8agrin@gmail.com>
Date:   Fri Apr 24 10:48:11 2015 -0700

    Add the tree control assets